### PR TITLE
New build targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - npm install
 
 script:
-  - npm run-script build
+  - npm run-script build --publish never

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - npm install
 
 script:
-  - npm run-script build --publish never
+  - npm run-script build

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "scripts/init.js",
   "scripts": {
     "start": "electron .",
-    "build": "electron-builder"
+    "build": "electron-builder --publish never"
   },
   "build": {
     "linux": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "zip",
         "AppImage",
         "deb",
-        "apk"
+        "apk",
+        "snap"
       ],
       "category": "Education",
       "artifactName": "${name}_${version}_linux.${ext}"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
       ],
       "category": "Education",
       "artifactName": "${name}_${version}_linux.${ext}"
-    }
+    },
+    "extraFiles": [
+      "duolingo-desktop.desktop"
+    ]
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,33 +5,35 @@
   "version": "2.0.0",
   "description": "A desktop client for Duolingo",
   "main": "scripts/init.js",
-  "dependencies": {
-    "app-module-path": "2.2.0"
-  },
   "scripts": {
     "start": "electron .",
     "build": "electron-builder"
+  },
+  "build": {
+    "linux": {
+      "target": [
+        "zip",
+        "AppImage",
+        "deb",
+        "apk"
+      ],
+      "category": "Education",
+      "artifactName": "${name}_${version}_linux.${ext}"
+    }
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hmlendea/duolingo-desktop.git"
   },
   "keywords": [
+    "Electron",
     "Duolingo"
   ],
   "author": "Horațiu Mlendea <Mlendea.Horatiu@GMail.com>",
-  "authorName": "Horațiu Mlendea",
-  "build": {
-    "linux": {
-      "target": "zip",
-      "category": "Education"
-    }
-  },
   "license": "GPL-3.0",
-  "bugs": {
-    "url": "https://github.com/hmlendea/duolingo-desktop/issues"
+  "dependencies": {
+    "app-module-path": "2.2.0"
   },
-  "homepage": "https://github.com/hmlendea/duolingo-desktop#readme",
   "devDependencies": {
     "electron": "^8.5.2",
     "electron-builder": "^22.5.1"


### PR DESCRIPTION
 - Added new build targets for `AppImage` (standalone binary), `deb` (Debian/Ubuntu), `apk` (Alipine Linux), and `snap` (for distros with snap support, like Ubuntu)
 - Included the desktop launcher file in the build output